### PR TITLE
Allow offsets higher than the number of documents

### DIFF
--- a/lib/document_mapper/query.rb
+++ b/lib/document_mapper/query.rb
@@ -43,7 +43,7 @@ module DocumentMapper
     def all
       result = @model.select(:where => @where, :order_by => @order_by)
       if @offset.present?
-        result = result.last(result.size - @offset)
+        result = result.last([result.size - @offset, 0].max)
       end
       if @limit.present?
         result = result.first(@limit)

--- a/test/document_mapper/document_mapper_test.rb
+++ b/test/document_mapper/document_mapper_test.rb
@@ -121,6 +121,10 @@ describe MyDocument do
     it 'should support offset and limit at the same time' do
       assert_equal_set [2,3], MyDocument.order_by(:id).offset(1).limit(2).all.map(&:id)
     end
+
+    it 'should not freak out about an offset higher than the document count' do
+      assert_equal_set [], MyDocument.order_by(:id).offset(5).all
+    end
   end
 
   describe 'resetting the MyDocument class' do


### PR DESCRIPTION
Ralph,

Hi - I'm using document_mapper to build my own blosxom/serious/whatever clone, and I quickly ran into the problem that I have an offset higher than the one blog post I currently have. I wrote this quick fix and test for it.
