### PR TITLE
Automatic 'slug' recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ doc.month                    # => 08
 doc.day                      # => 07
 ```
 
+### Slug recognition
+
+Similar to the date recognition described above, Document Mapper will automatically populate a document's `slug` attribute using its file name (unless `slug` is already given in the document front matter).
+
+For example, a file named `2011-12-24-happy-xmas.textile` will not only have its date set to `2011-12-24`, but its `slug` set to `happy-xmas`.
 
 ### Working with directories
 

--- a/lib/document_mapper/yaml_parsing.rb
+++ b/lib/document_mapper/yaml_parsing.rb
@@ -26,6 +26,14 @@ module DocumentMapper
         end
       end
 
+      if !self.attributes.has_key? :slug
+        begin
+          match = attributes[:file_name_without_extension].match(/(\d{4}-\d{1,2}-\d{1,2}[-_])?(.*)/)
+          self.attributes[:slug] = match[2]
+        rescue NoMethodError => err
+        end
+      end
+
       if self.attributes.has_key? :date
         self.attributes[:year] = self.attributes[:date].year
         self.attributes[:month] = self.attributes[:date].month

--- a/test/document_mapper/document_mapper_test.rb
+++ b/test/document_mapper/document_mapper_test.rb
@@ -74,6 +74,40 @@ describe MyDocument do
       end
     end
 
+    describe 'specifying the slug of the document' do
+      describe 'when a slug is defined in the document' do
+        before do
+          @document = MyDocument.from_file('test/documents/2010-08-08-test-document-file.textile')
+        end
+
+        it 'should return the slug defined in the document' do
+          assert_equal 'fancy-test', @document.slug
+        end
+      end
+
+      describe 'when no slug is defined in the document' do
+        describe 'when the file name contains no date' do
+          before do
+            @document = MyDocument.from_file('test/documents/document_with_date_in_yaml.textile')
+          end
+
+          it 'should get the slug from the file name' do
+            assert_equal 'document_with_date_in_yaml', @document.slug
+          end
+        end
+
+        describe 'when the file name contains a date' do
+          before do
+            @document = MyDocument.from_file('test/documents/2010-08-09-another-test-document.textile')
+          end
+
+          it 'should get the slug from the file name, without the date' do
+            assert_equal 'another-test-document', @document.slug
+          end
+        end
+      end
+    end
+
     describe 'loading a documents directory' do
       it 'should load all the documents in that directory' do
         MyDocument.directory = 'test/documents'
@@ -315,6 +349,7 @@ EOS
         id
         month
         seldom_attribute
+        slug
         special_attribute
         status
         tags

--- a/test/documents/2010-08-08-test-document-file.textile
+++ b/test/documents/2010-08-08-test-document-file.textile
@@ -1,6 +1,7 @@
 ---
 id: 1
 title: Some fancy title
+slug: fancy-test
 tags: [ruby]
 status: :published
 ---


### PR DESCRIPTION
Similar to the date, automatically extract the 'slug' attribute from the file name (if not already specified in the front matter).

For example, a file named `2011-12-24-happy-xmas.textile` will not only have its date set to `2011-12-24`, but its `slug` set to `happy-xmas`.
