### PR TITLE
allow multiple document classes to server multiple directories

### DIFF
--- a/lib/document_mapper/document.rb
+++ b/lib/document_mapper/document.rb
@@ -11,7 +11,7 @@ module DocumentMapper
     attr_accessor :attributes, :content
 
     included do
-      @@documents = []
+      @documents = []
     end
 
     def ==(other_document)
@@ -21,12 +21,12 @@ module DocumentMapper
 
     module ClassMethods
       def reset
-        @@documents = []
+        @documents = []
       end
 
       def reload
         self.reset
-        self.directory = @@directory.path
+        self.directory = @directory.path
       end
 
       def from_file(file_path)
@@ -38,22 +38,22 @@ module DocumentMapper
             :file_path => File.expand_path(file_path)
           }
           document.read_yaml
-          @@documents << document
+          @documents << document
         end
       end
 
       def directory=(new_directory)
         raise FileNotFoundError unless File.directory?(new_directory)
         self.reset
-        @@directory = Dir.new File.expand_path(new_directory)
-        @@directory.each do |file|
+        @directory = Dir.new File.expand_path(new_directory)
+        @directory.each do |file|
           next if file[0,1] == '.'
-          self.from_file [@@directory.path, file].join('/')
+          self.from_file [@directory.path, file].join('/')
         end
       end
 
       def select(options = {})
-        documents = @@documents.dup
+        documents = @documents.dup
         options[:where].each do |selector, selector_value|
           documents = documents.select do |document|
             next unless document.attributes.has_key? selector.attribute
@@ -95,19 +95,19 @@ module DocumentMapper
       end
 
       def all
-        @@documents
+        @documents
       end
 
       def first
-        @@documents.first
+        @documents.first
       end
 
       def last
-        @@documents.last
+        @documents.last
       end
 
       def attributes
-        @@documents.map(&:attributes).map(&:keys).flatten.uniq.sort
+        @documents.map(&:attributes).map(&:keys).flatten.uniq.sort
       end
     end
   end

--- a/test/document_mapper/document_mapper_test.rb
+++ b/test/document_mapper/document_mapper_test.rb
@@ -336,6 +336,16 @@ EOS
     end
   end
 
+  describe 'multiple document classes' do
+    it 'can serve multiple document directories' do
+      MyDocument.directory = 'test/documents'
+      MyOtherDocument.directory = 'test/other_documents'
+
+      assert_equal 4, MyDocument.all.count
+      assert_equal 1, MyOtherDocument.all.count
+    end
+  end
+
   def sample_file_path_1
     'test/documents/2010-08-08-test-document-file.textile'
   end

--- a/test/other_documents/2011-12-26-some-test-document.textile
+++ b/test/other_documents/2011-12-26-some-test-document.textile
@@ -1,0 +1,5 @@
+---
+title: Some test document
+---
+
+This is just some test document.

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -12,6 +12,10 @@ class MyDocument
   include DocumentMapper::Document
 end
 
+class MyOtherDocument
+  include DocumentMapper::Document
+end
+
 module MiniTest::Assertions
   def assert_equal_set exp, act, msg = nil
     msg = message(msg) { "Expected #{mu_pp(exp)}, not #{mu_pp(act)}" }


### PR DESCRIPTION
the class variables used in DocumentMapper::Document prevent using multiple
DocumentMapper::Document classes for different kinds of documents.

like e.g. i added a pages directory to the standard posts directory and would need
to manage those using two models.
